### PR TITLE
Replace the popup-content if it is already visible

### DIFF
--- a/source/popelt-v1.0-source.js
+++ b/source/popelt-v1.0-source.js
@@ -136,6 +136,8 @@ function Popelt(params){
 			popHtml = $('<div>').addClass(_popClass).addClass(_id).css('z-index',_zIndex+1).append(popContainer);
 			$('body').append(popOverlay);
 			$('body').append(popHtml);
+		} else {
+			$('.' + _popContentClass, $('.' + _popClass + '.' + _id)).empty().append(o.content);
 		}
 
 		// if external content, first show popup and fetch and directly show data in dom element


### PR DESCRIPTION
Useful for form submits (example code below):

```
    $(document).on('click', '.popup', function (e) {
        e.preventDefault();
        var p = new Popelt();
        $.get(e.target.href + '?mode=popup', function (data) {
            $('.pop-content').on('submit', 'form', function (e) {
                e.preventDefault();
                $.post(e.target.action + '?mode=popup', $(e.target).serialize(), function (data) {
                    p.setContent($(data));
                    p.show();
                });
            });
            p.setContent($(data));
            p.show();
        });
    })
```
